### PR TITLE
Use dual-stack sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ Overview of the examples
 | [Example 3](examples/example3) | systemd user service | 80/TCP, 443/TCP, 443/UDP | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | rootless podman | hello world web server |
 | [Example 4](examples/example4) | systemd user service | 80/TCP, 443/TCP, 443/UDP | :heavy_check_mark: |  :heavy_check_mark: | :heavy_check_mark: | rootless podman | http reverse proxy with TCP backends |
 
-> [!WARNING]
-> Currently I have only verified that _Example 1_ and _Example 2_ works. Consider _Example 3_, _Example 4_ as being work in progress.
-
-
 ## Using Caddy with socket activation
 
 While Caddy can create sockets by itself, there are security and performance advantages to using

--- a/examples/example1/caddy.socket
+++ b/examples/example1/caddy.socket
@@ -1,5 +1,7 @@
 [Socket]
-ListenStream=127.0.0.1:8080
+
+ListenStream=[::]:8080
+BindIPv6Only=both
 
 [Install]
 WantedBy=sockets.target

--- a/examples/example2/caddy.socket
+++ b/examples/example2/caddy.socket
@@ -1,5 +1,6 @@
 [Socket]
-ListenStream=0.0.0.0:8080
+ListenStream=[::]:8080
+BindIPv6Only=both
 
 [Install]
 WantedBy=sockets.target

--- a/examples/example3/caddy.socket
+++ b/examples/example3/caddy.socket
@@ -1,7 +1,8 @@
 [Socket]
-ListenStream=0.0.0.0:80
-ListenStream=0.0.0.0:443
-ListenDatagram=0.0.0.0:443
+ListenStream=[::]:80
+ListenStream=[::]:443
+ListenDatagram=[::]:443
+BindIPv6Only=both
 
 [Install]
 WantedBy=sockets.target

--- a/examples/example4/caddy.socket
+++ b/examples/example4/caddy.socket
@@ -1,14 +1,15 @@
 [Socket]
+BindIPv6Only=both
 
 ### sockets for the HTTP reverse proxy
 # fd/3
-ListenStream=0.0.0.0:80
+ListenStream=[::]:80
 
 # fd/4
-ListenStream=0.0.0.0:443
+ListenStream=[::]:443
 
 # fdgram/5
-ListenDatagram=0.0.0.0:443
+ListenDatagram=[::]:443
 
 ### socket for the admin API endpoint
 # fd/6


### PR DESCRIPTION
Use dual-stack sockets.

Some success was reported in issue 17, so I think we can remove the warning text
about work-in-progress.

Fixes: https://github.com/eriksjolund/podman-caddy-socket-activation/issues/17