### PR TITLE
example4: Add volumes. Replace nginx with static file server

### DIFF
--- a/examples/example4/Caddyfile
+++ b/examples/example4/Caddyfile
@@ -22,21 +22,21 @@ https://whoami.example.com {
 	reverse_proxy whoami.example.com:80
 }
 
-http://nginx.example.com {
-	bind fd/3 {
-		protocols h1
-	}
-	log
-	reverse_proxy nginx.example.com:80
+http://static.example.com {
+       bind fd/3 {
+               protocols h1
+       }
+       root * /static
+       file_server
 }
 
-https://nginx.example.com {
-	bind fd/4 {
-		protocols h1 h2
-	}
-	bind fdgram/5 {
-		protocols h3
-	}
-	log
-	reverse_proxy nginx.example.com:80
+https://static.example.com {
+       bind fd/4 {
+               protocols h1 h2
+       }
+       bind fdgram/5 {
+               protocols h3
+       }
+       root * /static
+       file_server
 }

--- a/examples/example4/caddy.container
+++ b/examples/example4/caddy.container
@@ -1,6 +1,13 @@
+[Unit]
+AssertPathExists=%h/Caddyfile
+AssertPathIsDirectory=%h/caddy_static
+
 [Container]
 Exec=/usr/bin/caddy run --config /etc/caddy/Caddyfile
 Image=docker.io/library/caddy:2.9.0-beta.3
 Network=mynet.network
 Notify=true
 Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z
+Volume=%h/caddy_static:/static:Z,ro
+Volume=caddy_config:/config
+Volume=caddy_data:/data

--- a/examples/example4/caddy_config.volume
+++ b/examples/example4/caddy_config.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=caddy_config

--- a/examples/example4/caddy_data.volume
+++ b/examples/example4/caddy_data.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=caddy_data

--- a/examples/example4/nginx.container
+++ b/examples/example4/nginx.container
@@ -1,4 +1,0 @@
-[Container]
-ContainerName=nginx.example.com
-Image=docker.io/library/nginx
-Network=mynet.network


### PR DESCRIPTION
Currently untested.

As I understand it, the line
```
Volume=caddy_data:/data
```
is needed to persist the TLS certificates.
(Otherwise TLS certificates are lost whenever Caddy is stopped)

Instead of having two backend web servers, just use one of them.
Keep _whoami_ and remove _nginx_.

Configure Caddy to act as a file server for requests to __https://static.example.com__