### PR TITLE
Add directory examples.under-development

### DIFF
--- a/examples.under-development/README.md
+++ b/examples.under-development/README.md
@@ -1,0 +1,8 @@
+### Examples that are under development
+
+> [!WARNING]
+> These examples are currently experiments that might not even work at all.
+> Instead of using long-lived work-in-progress draft PRs for
+> these experiments it is easier to look at the half-baked code by having the files
+> directly in the git main branch.
+> When an example looks good enough, it will be moved to the directory [../examples](../examples)


### PR DESCRIPTION
Add directory _examples.under-development_  for keeping some experiments that might become examples in the future.

__Rationale:__ Instead of using long-lived work-in-progress draft PRs for
these experiments it is easier to look at the half-baked code by having the files
directly in the git main branch.
