### PR TITLE
examples: remove disable_redirects

### DIFF
--- a/examples/example1/Caddyfile
+++ b/examples/example1/Caddyfile
@@ -1,5 +1,4 @@
 {
-	auto_https disable_redirects
 	admin off
 }
 

--- a/examples/example2/Caddyfile
+++ b/examples/example2/Caddyfile
@@ -1,5 +1,4 @@
 {
-	auto_https disable_redirects
 	admin off
 }
 

--- a/examples/example3/Caddyfile
+++ b/examples/example3/Caddyfile
@@ -1,5 +1,4 @@
 {
-	auto_https disable_redirects
 	admin off
 }
 

--- a/examples/example4/Caddyfile
+++ b/examples/example4/Caddyfile
@@ -1,5 +1,4 @@
 {
-	auto_https disable_redirects
 	admin fd/6
 }
 


### PR DESCRIPTION
Fixes: https://github.com/eriksjolund/podman-caddy-socket-activation/discussions/24