### PR TITLE
Remove build step

### DIFF
--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -30,8 +30,6 @@ Caddy is configured to reply _hello world_.
    mkdir -p ~/.config/systemd/user
    mkdir -p ~/.config/containers/systemd
    ```
-1. Build a caddy container image by following the instructions
-   in [../../build_caddy_container_image.md](build_caddy_container_image.md)
 1. Clone git repo
    ```
    git clone https://github.com/eriksjolund/podman-caddy-socket-activation.git

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -38,8 +38,6 @@ resolvable in public DNS.
    mkdir -p ~/.config/systemd/user
    mkdir -p ~/.config/containers/systemd
    ```
-1. Build a caddy container image by following the instructions in
-   [../../build_caddy_container_image.md](build_caddy_container_image.md)
 1. Clone git repo
    ```
    git clone https://github.com/eriksjolund/podman-caddy-socket-activation.git

--- a/examples/example3/README.md
+++ b/examples/example3/README.md
@@ -48,8 +48,6 @@ Caddy is configured to reply _hello world_.
    mkdir -p ~/.config/systemd/user
    mkdir -p ~/.config/containers/systemd
    ```
-1. Build a caddy container image by following the instructions in
-   [../../build_caddy_container_image.md](build_caddy_container_image.md)
 1. Clone git repo
    ```
    git clone https://github.com/eriksjolund/podman-caddy-socket-activation.git


### PR DESCRIPTION
Remove container image build step.

A pre-built container image is used instead. See for example:

https://github.com/eriksjolund/podman-caddy-socket-activation/blob/894f32c8a6cbf6742cafb57e06fc916501871758/examples/example1/caddy.container#L3