### PR TITLE
caddy release now has socket activation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ Socket activation support was added to Caddy in
 
 * https://github.com/caddyserver/caddy/pull/6573
 
-Socket activation support is planned for Caddy 2.9.0 (yet to be released).
-For the moment being you can use _docker.io/library/caddy:2.9.0-beta.3_
-which has socket activation support.
-
 Caddy does not make use of file descriptor names that can be retrieved with [sd_listen_fds_with_names()](https://www.freedesktop.org/software/systemd/man/latest/sd_listen_fds.html).
 Instead file descriptor numbers are specified.
 Do not use multiple socket units. Use one socket unit so that the file descriptor numbers can be mapped to the listening sockets that are configured with `ListenStream=` and `ListenDatagram=`.

--- a/examples.under-development/draft-example.nsenter/README.md
+++ b/examples.under-development/draft-example.nsenter/README.md
@@ -61,7 +61,7 @@ Configure _socket activation_ for the unix socket _/srv/caddy/caddy.sock_. Let C
 
 Alternative 1.
 
-Pull _docker.io/library/caddy:2.9.0-beta.3_ and extract the caddy binary
+Pull _docker.io/library/caddy_ and extract the caddy binary
 from the container image, then save the binary to `/usr/local/bin/caddy`
 
 <details>
@@ -78,11 +78,11 @@ from the container image, then save the binary to `/usr/local/bin/caddy`
    ```
 3. Pull the caddy container image
    ```
-   podman pull docker.io/library/caddy:2.9.0-beta.3
+   podman pull docker.io/library/caddy
    ```
 4. Create a temporary container that will be used for mounting the container file system.
    ```
-   podman create --name tmpctr docker.io/library/caddy:2.9.0-beta.3
+   podman create --name tmpctr docker.io/library/caddy
    ```
 5. Run command
    ```
@@ -121,7 +121,7 @@ from the container image, then save the binary to `/usr/local/bin/caddy`
 
 Alternative 2.
 
-Build and install /usr/local/bin/caddy from source code (use [v2.9.0-beta.3](https://github.com/caddyserver/caddy/releases/tag/v2.9.0-beta.3) or newer)
+Build and install /usr/local/bin/caddy from [caddy source code](https://github.com/caddyserver/caddy)
 
 ### Set up quadlets and systemd services
 

--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -9,7 +9,7 @@ graph TB
 ```
 
 Set up a systemd user service _example1.service_ for the user _test_ where rootless podman
-is running a _docker.io/library/caddy:2.9.0-beta.3_ container. Configure _socket activation_ for TCP port 8080.
+is running a _docker.io/library/caddy_ container. Configure _socket activation_ for TCP port 8080.
 Caddy is configured to reply _hello world_.
 
 1. Create a test user
@@ -32,7 +32,7 @@ Caddy is configured to reply _hello world_.
    ```
 1. Pull _caddy_ container image
    ```
-   podman pull docker.io/library/caddy:2.9.0-beta.3
+   podman pull docker.io/library/caddy
    ```
 1. Clone git repo
    ```

--- a/examples/example1/caddy.container
+++ b/examples/example1/caddy.container
@@ -1,6 +1,6 @@
 [Container]
 Exec=/usr/bin/caddy run --config /etc/caddy/Caddyfile
-Image=docker.io/library/caddy:2.9.0-beta.3
+Image=docker.io/library/caddy
 Network=none
 Notify=true
 Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -11,7 +11,7 @@ graph TB
 ```
 
 Set up a systemd user service _example2.service_ for the user _test_ where rootless podman is
-running the container image _docker.io/library/caddy:2.9.0-beta.3_. Configure _socket activation_ for TCP port 8080.
+running the container image _docker.io/library/caddy_. Configure _socket activation_ for TCP port 8080.
 The caddy container is acting as a HTTP reverse proxy that forwards requests to 2 backends.
 Requests to http://whoami.example.com:8080 are forwarded to the _whoami_ container.
 Requests to http://ngnix.example.com:8080 are forwarded to the _nginx_ container.
@@ -40,7 +40,7 @@ resolvable in public DNS.
    ```
 1. Pull _caddy_ container image
    ```
-   podman pull docker.io/library/caddy:2.9.0-beta.3
+   podman pull docker.io/library/caddy
    ```
 1. Pull _whoami_ container image
    ```

--- a/examples/example2/caddy.container
+++ b/examples/example2/caddy.container
@@ -1,6 +1,6 @@
 [Container]
 Exec=/usr/bin/caddy run --config /etc/caddy/Caddyfile
-Image=docker.io/library/caddy:2.9.0-beta.3
+Image=docker.io/library/caddy
 Network=mynet.network
 Notify=true
 Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z

--- a/examples/example3/README.md
+++ b/examples/example3/README.md
@@ -11,7 +11,7 @@ graph TB
 ```
 
 Set up a systemd user service _example3.service_ for the user _test_ where rootless podman is
-running a _docker.io/library/caddy:2.9.0-beta.3_ container. Configure _socket activation_ for the ports 80/TCP,
+running a _docker.io/library/caddy_ container. Configure _socket activation_ for the ports 80/TCP,
 443/TCP and 443/UDP. A TLS certificate is automatically retrieved with the
 [ACME](https://en.wikipedia.org/wiki/Automatic_Certificate_Management_Environment) prototol.
 Caddy is configured to reply _hello world_.
@@ -50,7 +50,7 @@ Caddy is configured to reply _hello world_.
    ```
 1. Pull _caddy_ container image
    ```
-   podman pull docker.io/library/caddy:2.9.0-beta.3
+   podman pull docker.io/library/caddy
    ```
 1. Clone git repo
    ```

--- a/examples/example3/caddy.container
+++ b/examples/example3/caddy.container
@@ -1,6 +1,6 @@
 [Container]
 Exec=/usr/bin/caddy run --config /etc/caddy/Caddyfile
-Image=docker.io/library/caddy:2.9.0-beta.3
+Image=docker.io/library/caddy
 Notify=true
 Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z
 Volume=caddy_config.volume:/config

--- a/examples/example4/README.md
+++ b/examples/example4/README.md
@@ -13,7 +13,7 @@ graph TB
 ```
 
 Set up a systemd user service _example4.service_ for the user _test_ where rootless podman is running
-the container image _docker.io/library/caddy:2.9.0-beta.3_.
+the container image _docker.io/library/caddy_.
 The caddy container is acting as an HTTP reverse proxy that forwards requests for
 https://whoami.example.com to a _whoami_ container.
 Caddy is also configured to be a static file server for requests to https://static.example.com.
@@ -77,7 +77,7 @@ Configure _socket activation_ for the unix socket _~/caddy.sock_. Let Caddy use 
    ```
 1. Pull _caddy_ container image
    ```
-   podman pull docker.io/library/caddy:2.9.0-beta.3
+   podman pull docker.io/library/caddy
    ```
 1. Pull _whoami_ container image
    ```

--- a/examples/example4/caddy.container
+++ b/examples/example4/caddy.container
@@ -4,7 +4,7 @@ AssertPathIsDirectory=%h/caddy_static
 
 [Container]
 Exec=/usr/bin/caddy run --config /etc/caddy/Caddyfile
-Image=docker.io/library/caddy:2.9.0-beta.3
+Image=docker.io/library/caddy
 Network=mynet.network
 Notify=true
 Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z


### PR DESCRIPTION
The container image __docker.io/library/caddy__ now supports _socket activation_

