### PR TITLE
Add useradd option --create-home

### DIFF
--- a/examples.under-development/draft-example.nsenter/README.md
+++ b/examples.under-development/draft-example.nsenter/README.md
@@ -70,7 +70,7 @@ from the container image, then save the binary to `/usr/local/bin/caddy`
 
 1. Create user
    ```
-   sudo useradd test
+   sudo useradd --create-home test
    ```
 2. Open a login shell
    ```
@@ -138,7 +138,7 @@ Build and install /usr/local/bin/caddy from [caddy source code](https://github.c
    Verify that the results match the left-most IPv4 address shown by the command `hostname -I`.
 1. Create a test user
    ```
-   sudo useradd test
+   sudo useradd --create-home test
    ```
 1. Open a shell for user _test_
    ```

--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -14,7 +14,7 @@ Caddy is configured to reply _hello world_.
 
 1. Create a test user
    ```
-   sudo useradd test
+   sudo useradd --create-home test
    ```
 1. Open a shell for user _test_
    ```

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -22,7 +22,7 @@ resolvable in public DNS.
 
 1. Create a test user
    ```
-   sudo useradd test
+   sudo useradd --create-home test
    ```
 1. Open a shell for user _test_
    ```

--- a/examples/example3/README.md
+++ b/examples/example3/README.md
@@ -32,7 +32,7 @@ Caddy is configured to reply _hello world_.
    Verify that the result matches the left-most IPv4 address shown by the command `hostname -I`.
 1. Create a test user
    ```
-   sudo useradd test
+   sudo useradd --create-home test
    ```
 1. Open a shell for user _test_
    ```

--- a/examples/example4/README.md
+++ b/examples/example4/README.md
@@ -59,7 +59,7 @@ Configure _socket activation_ for the unix socket _~/caddy.sock_. Let Caddy use 
    Verify that the results match the left-most IPv4 address shown by the command `hostname -I`.
 1. Create a test user
    ```
-   sudo useradd test
+   sudo useradd --create-home test
    ```
 1. Open a shell for user _test_
    ```


### PR DESCRIPTION
Add the option so that the instructions work on both Ubuntu and Fedora.

Reference: https://github.com/eriksjolund/podman-caddy-socket-activation/issues/34