### PR TITLE
example4: let proxy listen on custom network

### DIFF
--- a/examples/example4/Caddyfile
+++ b/examples/example4/Caddyfile
@@ -1,41 +1,48 @@
 {
+	auto_https disable_redirects
+	default_bind fd/4 {
+		protocols h1 h2
+	}
+	default_bind fdgram/5 {
+		protocols h3
+	}
 	admin fd/6
 }
 
-http://whoami.example.com {
+http:// {
 	bind fd/3 {
 		protocols h1
 	}
+	redir https://{host}{uri}
 	log
-	reverse_proxy whoami.example.com:80
 }
 
-https://whoami.example.com {
-	bind fd/4 {
-		protocols h1 h2
-	}
-	bind fdgram/5 {
-		protocols h3
-	}
+whoami.example.com {
+	reverse_proxy whoami:80
 	log
-	reverse_proxy whoami.example.com:80
 }
 
+static.example.com {
+	root * /static
+	file_server
+	log
+}
+
+# listen on custom network
+http://whoami.example.com {
+	bind 0.0.0.0 [::1] {
+		protocols h1
+	}
+	reverse_proxy whoami:80
+	log
+}
+
+# listen on custom network
 http://static.example.com {
-       bind fd/3 {
-               protocols h1
-       }
-       root * /static
-       file_server
-}
-
-https://static.example.com {
-       bind fd/4 {
-               protocols h1 h2
-       }
-       bind fdgram/5 {
-               protocols h3
-       }
-       root * /static
-       file_server
+	bind 0.0.0.0 [::1] {
+		protocols h1
+	}
+	root * /static
+	file_server
+	log
 }

--- a/examples/example4/caddy.container
+++ b/examples/example4/caddy.container
@@ -11,3 +11,5 @@ Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z
 Volume=%h/caddy_static:/static:Z,ro
 Volume=caddy_config.volume:/config
 Volume=caddy_data.volume:/data
+NetworkAlias=static.example.com
+NetworkAlias=whoami.example.com

--- a/examples/example4/mynet.network
+++ b/examples/example4/mynet.network
@@ -1,1 +1,2 @@
 [Network]
+NetworkName=mynet

--- a/examples/example4/whoami.container
+++ b/examples/example4/whoami.container
@@ -1,4 +1,4 @@
 [Container]
-ContainerName=whoami.example.com
+ContainerName=whoami
 Image=docker.io/traefik/whoami
 Network=mynet.network

--- a/show-caddy-logs-last-minute.bash
+++ b/show-caddy-logs-last-minute.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+journalctl --user \
+           --output json \
+           --invocation 0 \
+           --since "1 minute ago" \
+            -u caddy.service \
+               _SYSTEMD_USER_UNIT=caddy.service \
+               CONTAINER_NAME=caddy \
+  | jq 'select(.MESSAGE |
+               fromjson |
+               .logger == "http.log.access") |
+        .MESSAGE |
+        fromjson |
+        .request'


### PR DESCRIPTION
Design idea:
Add `NetworkAlias=whoami.example.com`
and `NetworkAlias=whoami.example.com`
to caddy.container so that for example connections from a container
on the custom network to whoami.example.com are made
to the caddy container.

Adjust Caddyfile so that caddy creates a listening
socket (TCP/80) on the custom network.
The socket-activated sockets are still used by caddy.

See also the diagram in [_Alternative 1: create extra socket and use NetworkAlias=_](https://github.com/eriksjolund/podman-networking-docs?tab=readme-ov-file#alternative-1-create-extra-socket-and-use-networkalias) which shows how `NetworkAlias=` can be used in a proxy quadlet.

Use short names in ContainerName=

Rename systemd-mynet to mynet

Add helper Bash script
show-caddy-logs-last-minute.bash
for using journalctl to show the caddy access log

Fixes: https://github.com/eriksjolund/podman-caddy-socket-activation/issues/40
Fixes: https://github.com/eriksjolund/podman-caddy-socket-activation/issues/42