### PR TITLE
Add `Options=isolate=true` to network quadlets

### DIFF
--- a/examples.under-development/draft-example.nsenter/mynet.network
+++ b/examples.under-development/draft-example.nsenter/mynet.network
@@ -1,1 +1,2 @@
 [Network]
+Options=isolate=true

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -178,6 +178,7 @@ The file [_mynet.network_](mynet.network) currently contains
 
 ```
 [Network]
+Options=isolate=true
 Internal=true
 Network=mynet
 ```

--- a/examples/example2/mynet.network
+++ b/examples/example2/mynet.network
@@ -1,3 +1,4 @@
 [Network]
+Options=isolate=true
 Internal=true
 NetworkName=mynet

--- a/examples/example4/mynet.network
+++ b/examples/example4/mynet.network
@@ -1,2 +1,3 @@
 [Network]
+Options=isolate=true
 NetworkName=mynet


### PR DESCRIPTION
Add `Options=isolate=true` to network quadlets.

Containers in different custom networks can't connect to each other if the networks were created
with `--opt=isolate=strict`

Here is an example:

#### without --opt=isolate=strict
```
$ podman network create mynet1
$ podman network create mynet2
$ podman run --rm --name ngi --network mynet1 -d docker.io/library/nginx
$ podman container inspect ngi | jq -r '.[0].NetworkSettings.Networks.mynet1.IPAddress'
10.89.10.2
$ podman run --rm --network mynet2 docker.io/library/fedora curl --connect-timeout 3 -sS 10.89.10.2 | head -4
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
```

#### with `--opt=isolate=strict`

```
$ podman network create --opt=isolate=strict mynet1
$ podman network create --opt=isolate=strict mynet2
$ podman run --rm --name ngi --network mynet1 -d docker.io/library/nginx
$ podman container inspect ngi | jq -r '.[0].NetworkSettings.Networks.mynet1.IPAddress'
10.89.12.2
$ podman run --rm --network mynet2 docker.io/library/fedora curl --connect-timeout 3 -sS 10.89.12.2
curl: (28) Connection timed out after 3001 milliseconds
```
