### PR TITLE
examples: remove disable_redirects

### DIFF
--- a/examples.under-development/draft-example.nsenter/Caddyfile
+++ b/examples.under-development/draft-example.nsenter/Caddyfile
@@ -1,5 +1,4 @@
 {
-	auto_https disable_redirects
 	admin fd/6
 }
 

--- a/examples/example4/Caddyfile
+++ b/examples/example4/Caddyfile
@@ -1,5 +1,4 @@
 {
-	auto_https disable_redirects
 	default_bind fd/4 {
 		protocols h1 h2
 	}


### PR DESCRIPTION
Fixes: https://github.com/eriksjolund/podman-caddy-socket-activation/discussions/24#discussioncomment-13846439