### PR TITLE
example1, example2, example3: support reload caddy.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,33 +71,6 @@ Do not use multiple socket units. Use one socket unit so that the file descripto
 Quote from man page [systemd.socket(5)](https://www.freedesktop.org/software/systemd/man/latest/systemd.socket.html):
 _"Sockets configured in one unit are passed in the order of configuration, but no ordering between socket units is specified"_
 
-### Support for reloading the Caddy configuration
-
-Here is an outline of how to allow reloading the Caddy configuration.
-
-To support reloading the Caddy configuration, do the following steps
-
-1. Bind-mount an empty directory into the Caddy container to the path `/caddy_adminsocket` (The path was arbitrarily chosen).
-2. Add the global Caddyfile option [`admin`](https://caddyserver.com/docs/caddyfile/options#admin) to the Caddyfile.
-   ```
-   admin unix//caddy_adminsocket/sock|0200
-   ```
-3. Add the systemd directive `ExecReload` under the `[Service]` section in the caddy container unit (quadlet).
-   ```
-   ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --force
-   ```
-   (`caddy` is an arbitrarily chosen name. It should match the name of the container that can be set with `ContainerName=` under the `[Container]` section)
-
-
-To reload the Caddyfile, run
-```
-systemctl --user reload caddy.service
-```
-
-See also:
-
-[Example 4](examples/example4) that is configured to allow reloading the Caddy configuration.
-
 > [!NOTE]
-> Reloading the caddy configuration does not currently work when [`admin`](https://caddyserver.com/docs/caddyfile/options#admin) is set to
-a file descriptor (see issue https://github.com/caddyserver/caddy/issues/6631).
+> Reloading the caddy configuration works when [`admin`](https://caddyserver.com/docs/caddyfile/options#admin)
+is set to a unix socket path or a TCP listening port, but not when set to a file descriptor (see issue https://github.com/caddyserver/caddy/issues/6631).

--- a/examples/example1/Caddyfile
+++ b/examples/example1/Caddyfile
@@ -1,5 +1,5 @@
 {
-	admin off
+	admin unix//run/admin.sock
 }
 
 http://localhost {

--- a/examples/example1/README.md
+++ b/examples/example1/README.md
@@ -29,6 +29,7 @@ Caddy is configured to reply _hello world_.
    ```
    mkdir -p ~/.config/systemd/user
    mkdir -p ~/.config/containers/systemd
+   mkdir ~/caddy_etc
    ```
 1. Pull _caddy_ container image
    ```
@@ -51,9 +52,9 @@ Caddy is configured to reply _hello world_.
 1. Install the _Caddyfile_
    ```
    cp podman-caddy-socket-activation/examples/example1/Caddyfile \
-      ~/Caddyfile
+      ~/caddy_etc/Caddyfile
    ```
-   (The path _~/Caddyfile_ was arbitrarily chosen)
+   (The path _~/caddy_etc/Caddyfile_ was arbitrarily chosen)
 1. Reload the systemd user manager
    ```
    systemctl --user daemon-reload

--- a/examples/example1/caddy.container
+++ b/examples/example1/caddy.container
@@ -1,6 +1,14 @@
+[Unit]
+AssertPathIsDirectory=%h/caddy_etc
+AssertPathExists=%h/caddy_etc/Caddyfile
+
+[Service]
+ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force
+
 [Container]
+ContainerName=caddy
 Exec=/usr/bin/caddy run --config /etc/caddy/Caddyfile
 Image=docker.io/library/caddy
 Network=none
 Notify=true
-Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z
+Volume=%h/caddy_etc:/etc/caddy:Z

--- a/examples/example2/Caddyfile
+++ b/examples/example2/Caddyfile
@@ -1,5 +1,5 @@
 {
-	admin off
+	admin unix//run/admin.sock
 }
 
 http://whoami.example.com {

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -37,6 +37,7 @@ resolvable in public DNS.
    ```
    mkdir -p ~/.config/systemd/user
    mkdir -p ~/.config/containers/systemd
+   mkdir ~/caddy_etc
    ```
 1. Pull _caddy_ container image
    ```
@@ -68,9 +69,9 @@ resolvable in public DNS.
 1. Install the _Caddyfile_
    ```
    cp podman-caddy-socket-activation/examples/example2/Caddyfile \
-      ~/Caddyfile
+      ~/caddy_etc/Caddyfile
    ```
-   (The path _~/Caddyfile_ was arbitrarily chosen)
+   (The path _~/caddy_etc/Caddyfile_ was arbitrarily chosen)
 1. Reload the systemd user manager
    ```
    systemctl --user daemon-reload

--- a/examples/example2/caddy.container
+++ b/examples/example2/caddy.container
@@ -1,6 +1,14 @@
+[Unit]
+AssertPathIsDirectory=%h/caddy_etc
+AssertPathExists=%h/caddy_etc/Caddyfile
+
+[Service]
+ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force
+
 [Container]
+ContainerName=caddy
 Exec=/usr/bin/caddy run --config /etc/caddy/Caddyfile
 Image=docker.io/library/caddy
 Network=mynet.network
 Notify=true
-Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z
+Volume=%h/caddy_etc:/etc/caddy:Z

--- a/examples/example3/Caddyfile
+++ b/examples/example3/Caddyfile
@@ -1,5 +1,5 @@
 {
-	admin off
+	admin unix//run/admin.sock
 }
 
 http://example.com {

--- a/examples/example3/README.md
+++ b/examples/example3/README.md
@@ -47,6 +47,7 @@ Caddy is configured to reply _hello world_.
    ```
    mkdir -p ~/.config/systemd/user
    mkdir -p ~/.config/containers/systemd
+   mkdir ~/caddy_etc
    ```
 1. Pull _caddy_ container image
    ```
@@ -74,9 +75,9 @@ Caddy is configured to reply _hello world_.
 1. Install the _Caddyfile_
    ```
    cp podman-caddy-socket-activation/examples/example3/Caddyfile \
-      ~/Caddyfile
+      ~/caddy_etc/Caddyfile
    ```
-   (The path _~/Caddyfile_ was arbitrarily chosen)
+   (The path _~/caddy_etc/Caddyfile_ was arbitrarily chosen)
 1. Edit _~/Caddyfile_ so that _example.com_ is replaced with the hostname of
    your computer.
 1. Reload the systemd user manager

--- a/examples/example3/caddy.container
+++ b/examples/example3/caddy.container
@@ -1,7 +1,15 @@
+[Unit]
+AssertPathIsDirectory=%h/caddy_etc
+AssertPathExists=%h/caddy_etc/Caddyfile
+
+[Service]
+ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force
+
 [Container]
+ContainerName=caddy
 Exec=/usr/bin/caddy run --config /etc/caddy/Caddyfile
 Image=docker.io/library/caddy
 Notify=true
-Volume=%h/Caddyfile:/etc/caddy/Caddyfile:Z
+Volume=%h/caddy_etc:/etc/caddy:Z
 Volume=caddy_config.volume:/config
 Volume=caddy_data.volume:/data

--- a/examples/example4/Caddyfile
+++ b/examples/example4/Caddyfile
@@ -5,7 +5,7 @@
 	default_bind fdgram/5 {
 		protocols h3
 	}
-	admin unix//caddy_adminsocket/sock|0200
+	admin unix//run/admin.sock
 }
 
 http:// {

--- a/examples/example4/README.md
+++ b/examples/example4/README.md
@@ -80,6 +80,8 @@ with an HTTP reverse proxy, see
    ```
    mkdir -p ~/.config/systemd/user
    mkdir -p ~/.config/containers/systemd
+   mkdir ~/caddy_etc
+   mkdir ~/caddy_static
    ```
 1. Pull _caddy_ container image
    ```
@@ -113,16 +115,12 @@ with an HTTP reverse proxy, see
    cp podman-caddy-socket-activation/examples/example4/*.volume \
       ~/.config/containers/systemd/
    ```
-1. Create directories
-   ```
-   mkdir ~/caddy_etc ~/caddy_static ~/caddy_adminsocket
-   ```
 1. Install the _Caddyfile_
    ```
    cp podman-caddy-socket-activation/examples/example4/Caddyfile \
       ~/caddy_etc/Caddyfile
    ```
-   (The path _~/Caddyfile_ was arbitrarily chosen)
+   (The path _~/caddy_etc/Caddyfile_ was arbitrarily chosen)
 1. Edit _~/Caddyfile_ so that _example.com_ is replaced with the hostname of
    your computer.
 1. Create a static files

--- a/examples/example4/caddy.container
+++ b/examples/example4/caddy.container
@@ -1,11 +1,10 @@
 [Unit]
-AssertPathIsDirectory=%h/caddy_adminsocket
 AssertPathIsDirectory=%h/caddy_etc
 AssertPathExists=%h/caddy_etc/Caddyfile
 AssertPathIsDirectory=%h/caddy_static
 
 [Service]
-ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --force
+ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force
 
 [Container]
 ContainerName=caddy
@@ -15,7 +14,6 @@ Network=mynet.network
 Notify=true
 Volume=%h/caddy_etc:/etc/caddy:Z
 Volume=%h/caddy_static:/static:Z,ro
-Volume=%h/caddy_adminsocket:/caddy_adminsocket:Z
 Volume=caddy_config.volume:/config
 Volume=caddy_data.volume:/data
 NetworkAlias=static.example.com

--- a/examples/example4/caddy.socket
+++ b/examples/example4/caddy.socket
@@ -11,11 +11,6 @@ ListenStream=[::]:443
 # fdgram/5
 ListenDatagram=[::]:443
 
-### socket for the admin API endpoint
-# fd/6
-ListenStream=%t/caddy.sock
-SocketMode=0600
-
 [Install]
 WantedBy=sockets.target
 


### PR DESCRIPTION
In example1, example2, example3 add support for
`systemctl --user reload caddy.service`

Use admin socket path: `/run/admin.sock`
(The admin socket is no longer in a bind-mounted directory)

README.md: remove paragraph "_Support for reloading the Caddy configuration_" (All examples now contain reload functionality)