### PR TITLE
Add `Sockets=caddy.socket` for clarity

### DIFF
--- a/examples/example1/caddy.container
+++ b/examples/example1/caddy.container
@@ -4,6 +4,7 @@ AssertPathExists=%h/caddy_etc/Caddyfile
 
 [Service]
 ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force
+Sockets=caddy.socket
 
 [Container]
 ContainerName=caddy

--- a/examples/example2/caddy.container
+++ b/examples/example2/caddy.container
@@ -4,6 +4,7 @@ AssertPathExists=%h/caddy_etc/Caddyfile
 
 [Service]
 ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force
+Sockets=caddy.socket
 
 [Container]
 ContainerName=caddy

--- a/examples/example3/caddy.container
+++ b/examples/example3/caddy.container
@@ -4,6 +4,7 @@ AssertPathExists=%h/caddy_etc/Caddyfile
 
 [Service]
 ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force
+Sockets=caddy.socket
 
 [Container]
 ContainerName=caddy

--- a/examples/example4/caddy.container
+++ b/examples/example4/caddy.container
@@ -5,6 +5,7 @@ AssertPathIsDirectory=%h/caddy_static
 
 [Service]
 ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force
+Sockets=caddy.socket
 
 [Container]
 ContainerName=caddy


### PR DESCRIPTION
Setting Sockets= is strictly not needed because
the socket unit and the service unit shares the same name (excluding the suffix). For details, see
https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Sockets=
