### PR TITLE
Fix HTTP redirection in example4

### DIFF
--- a/examples/example4/Caddyfile
+++ b/examples/example4/Caddyfile
@@ -16,6 +16,8 @@
 		protocols h3
 	}
 	admin unix//run/admin.sock
+
+	auto_https disable_redirects
 }
 
 http:// {


### PR DESCRIPTION
Caddy documentation says:

"If you already have a server listening on the HTTP port, the HTTP->HTTPS redirect routes will be inserted after your routes with a host matcher, but before a user-defined catch-all route."

https://caddyserver.com/docs/automatic-https

This means the route in the example does not actually get used without disabling the automatically generated route.