### PR TITLE
Allow caddy.socket to be started as a dependency

### DIFF
--- a/examples.under-development/draft-example.nsenter/caddy.service
+++ b/examples.under-development/draft-example.nsenter/caddy.service
@@ -1,6 +1,8 @@
 [Unit]
 AssertPathExists=/srv/caddy/Caddyfile
 AssertPathIsDirectory=/srv/caddy/caddy_static
+After=caddy.socket
+Requires=caddy.socket
 
 [Service]
 CapabilityBoundingSet=

--- a/examples.under-development/example99/example99.container.in
+++ b/examples.under-development/example99/example99.container.in
@@ -1,6 +1,8 @@
 [Unit]
 Requires=user@${envsubst_uid}.service
 After=user@${envsubst_uid}.service
+After=caddy.socket
+Requires=caddy.socket
 RequiresMountsFor=/run/user/${envsubst_uid}/containers
 
 AssertPathIsDirectory=/home/${envsubst_user}/caddy_etc

--- a/examples/example1/caddy.container
+++ b/examples/example1/caddy.container
@@ -1,6 +1,8 @@
 [Unit]
 AssertPathIsDirectory=%h/caddy_etc
 AssertPathExists=%h/caddy_etc/Caddyfile
+After=caddy.socket
+Requires=caddy.socket
 
 [Service]
 ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force

--- a/examples/example2/caddy.container
+++ b/examples/example2/caddy.container
@@ -1,6 +1,8 @@
 [Unit]
 AssertPathIsDirectory=%h/caddy_etc
 AssertPathExists=%h/caddy_etc/Caddyfile
+After=caddy.socket
+Requires=caddy.socket
 
 [Service]
 ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force

--- a/examples/example3/caddy.container
+++ b/examples/example3/caddy.container
@@ -1,6 +1,8 @@
 [Unit]
 AssertPathIsDirectory=%h/caddy_etc
 AssertPathExists=%h/caddy_etc/Caddyfile
+After=caddy.socket
+Requires=caddy.socket
 
 [Service]
 ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force

--- a/examples/example4/caddy.container
+++ b/examples/example4/caddy.container
@@ -2,6 +2,8 @@
 AssertPathIsDirectory=%h/caddy_etc
 AssertPathExists=%h/caddy_etc/Caddyfile
 AssertPathIsDirectory=%h/caddy_static
+After=caddy.socket
+Requires=caddy.socket
 
 [Service]
 ExecReload=podman exec caddy /usr/bin/caddy reload --config /etc/caddy/Caddyfile --address unix//run/admin.sock --force


### PR DESCRIPTION
Fixes: https://github.com/eriksjolund/podman-caddy-socket-activation/issues/74