### PR TITLE
Prefer `isolate=strict` to `isolate=true`

### DIFF
--- a/examples.under-development/draft-example.nsenter/mynet.network
+++ b/examples.under-development/draft-example.nsenter/mynet.network
@@ -1,2 +1,2 @@
 [Network]
-Options=isolate=true
+Options=isolate=strict

--- a/examples.under-development/example99/example99-net.network
+++ b/examples.under-development/example99/example99-net.network
@@ -1,4 +1,4 @@
 [Network]
-Options=isolate=true
+Options=isolate=strict
 # To give the containers access to the internet, remove the line `Internal=true`
 Internal=true

--- a/examples/example2/README.md
+++ b/examples/example2/README.md
@@ -179,7 +179,7 @@ The file [_mynet.network_](mynet.network) currently contains
 
 ```
 [Network]
-Options=isolate=true
+Options=isolate=strict
 Internal=true
 Network=mynet
 ```

--- a/examples/example2/mynet.network
+++ b/examples/example2/mynet.network
@@ -1,4 +1,4 @@
 [Network]
-Options=isolate=true
+Options=isolate=strict
 Internal=true
 NetworkName=mynet

--- a/examples/example4/mynet.network
+++ b/examples/example4/mynet.network
@@ -1,3 +1,3 @@
 [Network]
-Options=isolate=true
+Options=isolate=strict
 NetworkName=mynet


### PR DESCRIPTION
Fixing a small mistake. Actually, I wanted to write

```
Options=isolate=strict
```

when I added those options before.
Somehow, I mixed it up and wrote

```
Options=isolate=true
```

In any case, it's not a big difference. The value `strict` is more restricted.
For details, see
https://github.com/eriksjolund/podman-networking-docs#custom-network-option-isolate

__Side note:__ 
In Podman 6.0 the new default value is `strict` instead of `true`.